### PR TITLE
Add gateway urls

### DIFF
--- a/dcejson_exporter.py
+++ b/dcejson_exporter.py
@@ -292,7 +292,7 @@ class MessageProvenance: # Recorded history of a particular message. Sequence of
         assert observation.message_id == self.message_id
         # If we now have two deletion observations, just keep the earlier one
         if observation.dmo is None and self.observations[-1].dmo is None:
-            observations[-1] = min(observation, observations[-1])
+            self.observations[-1] = min(observation, self.observations[-1])
         self.observations.append(observation)
         self.observations.sort()
     """ Returns (author id, author username) if we've observed it, otherwise (None, None). """

--- a/wumpus_in_the_middle.py
+++ b/wumpus_in_the_middle.py
@@ -128,7 +128,15 @@ class DiscordArchiver:
     def websocket_message(self, flow: http.HTTPFlow):
         if flow.request.url not in (
             "https://gateway.discord.gg/?encoding=etf&v=9&compress=zlib-stream",
-            "https://gateway.discord.gg/?encoding=json&v=9&compress=zlib-stream"
+            "https://gateway.discord.gg/?encoding=json&v=9&compress=zlib-stream",
+            "https://gateway-us-east1-a.discord.gg:443/?encoding=etf&v=9&compress=zlib-stream",
+            "https://gateway-us-east1-a.discord.gg:443/?encoding=json&v=9&compress=zlib-stream",
+            "https://gateway-us-east1-b.discord.gg:443/?encoding=etf&v=9&compress=zlib-stream",
+            "https://gateway-us-east1-b.discord.gg:443/?encoding=json&v=9&compress=zlib-stream",
+            "https://gateway-us-east1-c.discord.gg:443/?encoding=etf&v=9&compress=zlib-stream",
+            "https://gateway-us-east1-c.discord.gg:443/?encoding=json&v=9&compress=zlib-stream",
+            "https://gateway-us-east1-d.discord.gg:443/?encoding=etf&v=9&compress=zlib-stream",
+            "https://gateway-us-east1-d.discord.gg:443/?encoding=json&v=9&compress=zlib-stream"
         ):
             if flow.request.url.startswith("https://gateway.discord.gg/"):
                 log_info("Found a weird Gateway connection: {}. Did Discord update its API?".format(flow.request.url))


### PR DESCRIPTION
Fixes:
```
[22:18:45.199] ☎️  Wumpus In The Middle: Unrecognized websocket url: https://gateway-us-east1-d.discord.gg/?encoding=etf&v=9&compress=zlib-stream
127.0.0.1:50178 <- WebSocket binary message <- gateway-us-east1-d.discord.gg:443/?encoding=etf&v=9&compress=zlib-stream
```

`gateway-us-east1-a.discord.gg`, `gateway-us-east1-b.discord.gg` and `gateway-us-east1-c.discord.gg` urls were guessed based on:
https://github.com/Cyanic76/Hosts/blob/f139ae4133909b406cbdf2abc48eacceabbae91f/corporations/Social/discord.txt#L16C1-L19C38


Note: regex may be a better solution